### PR TITLE
Update to not change the file every time

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,18 @@ async function main() {
     path.join(__dirname, "README_template.md"),
     "utf8",
   );
+  const current = await fs.readFileSync(
+    path.join(__dirname, "README.md"),
+    "utf8",
+  );
   const repos = await get_repos("obsivium");
   console.log(repos);
   const repoDetails = repos.map(get_repo_details).join("");
-  const updatedTemplate = change_time(
-    template.replace("{{projects}}", repoDetails),
-  );
-  await fs.writeFileSync(path.join(__dirname, "README.md"), updatedTemplate);
+  const updatedTemplate = template.replace("{{projects}}", repoDetails),
+
+  if (updatedTemplate != current){
+    await fs.writeFileSync(path.join(__dirname, "README.md"), updatedTemplate);
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary by Sourcery

Avoid rewriting the README file on each run by comparing the newly generated content with the existing file and only updating it if there are differences.

Enhancements:
- Read the existing README.md file and generate the new content without automatically updating timestamps
- Add a conditional check to write the file only if the updated content differs from the current one